### PR TITLE
Allow Query CI to take more than 14 dates

### DIFF
--- a/R/intensity.R
+++ b/R/intensity.R
@@ -18,6 +18,8 @@ get_british_ci <-
     
     if (all(is.null(c(start, end)))) {
       call <- url
+      result <- query_british_ci_api(call)
+      return(result)
     } else if (all(!is.null(c(start, end)))) {
       from_date <- paste0(as.Date(start), 'T00:00Z/')
       to_date <- paste0(as.Date(end), 'T23:59Z')


### PR DESCRIPTION
Please don't merge this straight away. The code is more to discuss the idea before I go down a rabbit hole.

I was trying to work out the best way to allow date ranges greater than 14 days to be queried. I felt amending the original `get_british_ci` function was the best way to do this rather than creating an additional function. 

I think there were multiple ways to structure the code, but my preferred way is to abstract the API call from the code that does the error handling and the splitting of dates. So in this format:

- `query_british_ci_api`: does the API call and restructures the data into a data frame
- `get_british_ci` : checks the 'start' and 'end' date, then creates the API calls for each 14 day period. This is then fed into the `query_british_ci_api`

The alternative to this is just have it all within the 'get_british_ci', but I thought this might be a bit too messy.

The change looks more significant than I think it actually is. Part of it is just shuffling the order things happen.

What are your thoughts with this design approach? If you liked it, I was keen to change all of the API calls (regional, energy intensity) to follow this?

P.S. Other comments are welcome on code style and conventions. I'm not super experienced in making R packages so not entirely confident on all the things to follow.